### PR TITLE
Fix subfigures

### DIFF
--- a/src/plugins/figure/commands.js
+++ b/src/plugins/figure/commands.js
@@ -56,34 +56,36 @@ export function insertSubfigure(change, media) {
         return
     }
 
-    if (node.nodes.first().type !== 'figure') {
-        // Figure has no sub-figures yet, convert its child into a sub-figure.
-        change.wrapBlockAtRange(
-            Range.create().moveToRangeOfNode(node),
-            'figure',
-        )
-    }
+    change.withoutNormalizing(() => {
+        if (node.nodes.first().type !== 'figure') {
+            // Figure has no sub-figures yet, convert its child into a sub-figure.
+            change.wrapBlockAtRange(
+                Range.create().moveToRangeOfNode(node),
+                'figure',
+            )
+        }
 
-    const image = Block.create({
-        type: media.mime.split('/', 1)[0],
-        data: { src: media.name },
+        const image = Block.create({
+            type: media.mime.split('/', 1)[0],
+            data: { src: media.name },
+        })
+
+        const media_node = Block.create({
+            type: 'media',
+            nodes: [image],
+            data: { alt: media.alt },
+        })
+
+        const subfigure = Block.create({
+            type: 'figure',
+            nodes: [media_node],
+        })
+
+        const index = node.nodes.last().type === 'figure_caption'
+            ? node.nodes.size - 1
+            : node.nodes.size
+        change.insertNodeByKey(node.key, index, subfigure)
     })
-
-    const media_node = Block.create({
-        type: 'media',
-        nodes: [image],
-        data: { alt: media.alt },
-    })
-
-    const subfigure = Block.create({
-        type: 'figure',
-        nodes: [media_node],
-    })
-
-    const index = node.nodes.last().type === 'figure_caption'
-        ? node.nodes.size - 1
-        : node.nodes.size
-    change.insertNodeByKey(node.key, index, subfigure)
 }
 
 /**

--- a/src/plugins/figure/schema.js
+++ b/src/plugins/figure/schema.js
@@ -80,7 +80,7 @@ export default {
                 first: { type: 'figure' },
             },
             nodes: [
-                { match: { type: 'figure' }, min: 2 },
+                { match: [{ type: 'figure' }, { type: 'figure_caption' } ], min: 2 },
             ],
             normalize: normalizeFigure,
         },

--- a/src/plugins/figure/schema.js
+++ b/src/plugins/figure/schema.js
@@ -4,7 +4,6 @@
 
 function normalizeFigure(change, error) {
     const { code: violation, key, node, child } = error
-    console.log('normalizeFigure', violation, node.toJS())
 
     switch (violation) {
     // Unwrap invalid nodes outside a figure.


### PR DESCRIPTION
When user remove one of subfigures, the second one should be unwrapped.
https://trello.com/c/Vjj2rbgO/302-subfigure-error

There is also new error with slate-counters, which is counting subfigures like this:
```
Figure 1
   Figure 2
   Figure 3
```
https://trello.com/c/wg0m9oFd/501-wrong-counters-for-subfigures