### PR TITLE
Preformat tag

### DIFF
--- a/src/cnxml/document.js
+++ b/src/cnxml/document.js
@@ -251,6 +251,31 @@ export const MEDIA_ALT = block('div', de_media_alt, 'media_alt', se_media_alt)
 
 export const PARA = block('para', text('paragraph'), 'paragraph', 'para')
 
+/**
+ * Process data for preformat tags.
+ *
+ * Preformat tag may in CNXML may have display="inline" attribute, but since
+ * <pre> tag is block element we support only this variation.
+ */
+function de_preformat(el, next) {
+    return {
+        type: 'preformat',
+        nodes: next(el.childNodes),
+    }
+}
+
+/**
+ * Serializer for preformat.
+ */
+function se_preformat(obj, children) {
+    return <preformat id={obj.key}>
+        {children}
+    </preformat>
+}
+
+export const PREFORMAT = block(
+    'preformat', de_preformat, 'preformat', se_preformat)
+
 export const PROBLEM = block(
     'problem', 'exercise_problem', 'exercise_problem', 'problem')
 
@@ -276,6 +301,7 @@ export const DOCUMENT = [
     MEDIA,
     MEDIA_ALT,
     PARA,
+    PREFORMAT,
     PROBLEM,
     QUOTE,
     SECTION,

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -11,6 +11,7 @@ import Footnote from './footnote'
 import GlossaryDocument from './glossary'
 import List from './list'
 import Media from './media'
+import Preformat from './preformat'
 import Quotation from './quotation'
 import Section from './section'
 import Term from './term'
@@ -31,6 +32,7 @@ export {
     Footnote,
     List,
     Media,
+    Preformat,
     Quotation,
     Section,
     Term,
@@ -39,15 +41,22 @@ export {
     XReference,
 }
 
+const DEFAULT_TEXT_OPTIONS = {
+    preformat: {
+        inlines: ['code', 'docref', 'link', 'term', 'xref'],
+    },
+}
+
 /**
  * Collection of plugins for working with text content of a CNX document.
  *
  * @param {string[]|null} options.marks List of additional mark types allowed
  *                                      in text content.
  * @param {object?} options.code options for `Code`
+ * @param {object?} options.preformat options for `Preformat`
  * @param {object?} options.term options for `Term`
  */
-export function TextContent(options={}) {
+export function TextContent(options=DEFAULT_TEXT_OPTIONS) {
     const marks = [
         ...options.marks || [],
         'strong',
@@ -60,6 +69,7 @@ export function TextContent(options={}) {
     return [
         Code(options.code),
         Footnote({ marks }),
+        Preformat({ marks, ...options.preformat }),
         Term({ marks, ...options.term }),
         Text({ marks }),
         XReference(),
@@ -90,6 +100,7 @@ export function Document(options={}) {
     const content = [
         ...options.content || [],
         'paragraph',
+        'preformat',
         'quotation',
         'ul_list',
         'ol_list',

--- a/src/plugins/preformat/handlers.js
+++ b/src/plugins/preformat/handlers.js
@@ -1,0 +1,77 @@
+// Copyright 2019 OpenStax Poland
+// Licensed under the MIT license. See LICENSE file in the project root for
+// full license text.
+
+export default function onKeyDown(event, change, next) {
+    switch (event.key) {
+    case 'Enter':
+        return onEnter(event, change) || next()
+
+    case 'Backspace':
+        return onBackspace(event, change) || next()
+
+    default:
+        return next()
+    }
+}
+
+function onEnter(event, change) {
+    const { value } = change
+
+    const preformat = value.startBlock && value.startBlock.type === 'preformat'
+    if (!preformat) return false
+
+    // Add new line
+    if (event.shiftKey) {
+        return change.insertText('\n')
+    }
+
+    const { selection, startBlock } = value
+
+    const isAtEnd = selection.start.isAtEndOfNode(startBlock)
+        && selection.end.isAtEndOfNode(startBlock)
+
+    const lastNodeIsEmpty = startBlock.getText()
+        .split(/\r?\n/)
+        .pop() === ''
+
+    // Add new paragraph and unwrap block
+    if (isAtEnd && lastNodeIsEmpty) {
+        change.deleteBackward()
+        change.insertBlock('paragraph')
+        return change.unwrapBlock('preformat')
+    }
+
+    return change.insertText('\n')
+}
+
+function onBackspace(event, change) {
+    const { value } = change
+
+    const preformat = value.startBlock.type === 'preformat'
+        ? value.startBlock
+        : null
+
+    if (!preformat) return false
+
+    const { selection } = value
+
+    const isAtStart = selection.start.isAtStartOfNode(preformat)
+        && selection.end.isAtStartOfNode(preformat)
+
+    if (isAtStart) {
+        // Split preformat block at first \n
+        const texts = preformat.getText().split(/\r?\n/)
+        change.removeNodeByKey(preformat.key)
+        const firstText = texts.shift()
+        change.insertText(firstText)
+        if (texts.length) {
+            change.insertBlock('preformat')
+            change.insertText(texts.join('\n'))
+        }
+        change.moveToEndOfPreviousBlock()
+        return change.moveBackward(firstText.length)
+    }
+
+    return false
+}

--- a/src/plugins/preformat/index.js
+++ b/src/plugins/preformat/index.js
@@ -1,0 +1,27 @@
+// Copyright 2019 OpenStax Poland
+// Licensed under the MIT license. See LICENSE file in the project root for
+// full license text.
+
+import onKeyDown from './handlers'
+import renderBlock from './render'
+import make_schema from './schema'
+
+/**
+ * @param {string[]} options.inlines - List of inline types which may appear
+ *                                     inside a preformat fragment.
+ * @param {string[]} options.marks - List of mark types which may appear inside
+ *                                   a preformat.
+ */
+export default function Preformat(options={}) {
+    const {
+        inlines = [],
+        marks = [],
+    } = options
+
+    const schema = make_schema({
+        inlines,
+        marks,
+    })
+
+    return { onKeyDown, renderBlock, schema }
+}

--- a/src/plugins/preformat/render.js
+++ b/src/plugins/preformat/render.js
@@ -1,0 +1,17 @@
+// Copyright 2019 OpenStax Poland
+// Licensed under the MIT license. See LICENSE file in the project root for
+// full license text.
+
+import React from 'react'
+
+export default function renderBlock(
+    { node, children, attributes },
+    editor,
+    next
+) {
+    if (node.type === 'preformat') {
+        return <pre className="preformat" {...attributes}>{children}</pre>
+    }
+
+    return next()
+}

--- a/src/plugins/preformat/schema.js
+++ b/src/plugins/preformat/schema.js
@@ -1,0 +1,35 @@
+// Copyright 2019 OpenStax Poland
+// Licensed under the MIT license. See LICENSE file in the project root for
+// full license text.
+
+function normalizePreformatBlock(change, error) {
+    const { child, code } = error
+
+    switch (code) {
+    case 'child_type_invalid':
+        change.unwrapNodeByKey(child.key)
+        break
+
+    default:
+        /* istanbul ignore next */
+        console.warn('Unhandled preformat violation:', code)
+    }
+}
+
+export default function schema({ marks = [], inlines = [] }) {
+    const content = [
+        ...inlines.map(type => ({ type })),
+        { object: 'text' },
+    ]
+    const marksTypes = marks.map(type => ({ type }))
+
+    return {
+        blocks: {
+            preformat: {
+                nodes: [{ match: content }],
+                marks: marksTypes,
+                normalize: normalizePreformatBlock,
+            },
+        },
+    }
+}

--- a/test/cnxml/de/preformat.js
+++ b/test/cnxml/de/preformat.js
@@ -1,0 +1,21 @@
+/** @jsx h */
+
+export const input = cnxml`
+<preformat id="n1">Preformat\nmore preformat\nthird line</preformat>
+<para>Some <preformat display="inline">preformat</preformat> text</para>
+`
+
+export const outputContent = <value>
+    <document>
+        <preformat key="n1">
+            Preformat
+            {'\n'}
+            more preformat
+            {'\n'}
+            third line
+        </preformat>
+        <p>Some </p>
+        <preformat>preformat</preformat>
+        <p> text</p>
+    </document>
+</value>

--- a/test/cnxml/se/preformat.js
+++ b/test/cnxml/se/preformat.js
@@ -1,0 +1,23 @@
+/** @jsx h */
+
+export const inputContent = <value>
+    <document>
+        <preformat key="n1">
+            Preformat
+            {'\n'}
+            more preformat
+            {'\n'}
+            third line
+        </preformat>
+        <p>Some </p>
+        <preformat>preformat</preformat>
+        <p> text</p>
+    </document>
+</value>
+
+export const output = cnxml`
+<preformat id="n1">Preformat\nmore preformat\nthird line</preformat>
+<para>Some </para>
+<preformat>preformat</preformat>
+<para> text</para>
+`

--- a/test/plugins/index.js
+++ b/test/plugins/index.js
@@ -37,6 +37,7 @@ describe('Plugins', () => {
     fixtures(__dirname, 'figure', testPlugin(CONTENT_PLUGINS))
     fixtures(__dirname, 'footnote', testPlugin(CONTENT_PLUGINS))
     fixtures(__dirname, 'list', testPlugin(CONTENT_PLUGINS))
+    fixtures(__dirname, 'preformat', testPlugin(CONTENT_PLUGINS))
     fixtures(__dirname, 'quotation', testPlugin(CONTENT_PLUGINS))
     fixtures(__dirname, 'section', testPlugin(CONTENT_PLUGINS))
     fixtures(__dirname, 'term', testPlugin(CONTENT_PLUGINS))

--- a/test/plugins/preformat/handle-backspace-lines.js
+++ b/test/plugins/preformat/handle-backspace-lines.js
@@ -1,0 +1,26 @@
+/** @jsx h */
+
+export default editor => editor.run('onKeyDown', { key: 'Backspace' })
+
+export const input = <value>
+    <document>
+        <p>Before</p>
+        <preformat>
+            <cursor/>Some preformat
+            {'\n'}next line
+            {'\n'}another line
+        </preformat>
+        <p>After</p>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <p>Before<cursor/>Some preformat</p>
+        <preformat>
+            next line
+            {'\n'}another line
+        </preformat>
+        <p>After</p>
+    </document>
+</value>

--- a/test/plugins/preformat/handle-backspace.js
+++ b/test/plugins/preformat/handle-backspace.js
@@ -1,0 +1,18 @@
+/** @jsx h */
+
+export default editor => editor.run('onKeyDown', { key: 'Backspace' })
+
+export const input = <value>
+    <document>
+        <p>Before</p>
+        <preformat><cursor/>Some preformat</preformat>
+        <p>After</p>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <p>Before<cursor/>Some preformat</p>
+        <p>After</p>
+    </document>
+</value>

--- a/test/plugins/preformat/handle-enter.js
+++ b/test/plugins/preformat/handle-enter.js
@@ -1,0 +1,23 @@
+/** @jsx h */
+
+export default editor => {
+    editor.run('onKeyDown', { key: 'Enter' })
+    editor.run('onKeyDown', { key: 'Enter' })
+}
+
+export const input = <value>
+    <document>
+        <preformat>
+            Some preformat<cursor/>
+        </preformat>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <preformat>
+            Some preformat
+        </preformat>
+        <p><cursor/></p>
+    </document>
+</value>

--- a/test/plugins/preformat/handle-shift-enter.js
+++ b/test/plugins/preformat/handle-shift-enter.js
@@ -1,0 +1,26 @@
+/** @jsx h */
+
+export default editor => {
+    editor.run('onKeyDown', { key: 'Enter', shiftKey: true })
+    editor.run('onKeyDown', { key: 'Enter', shiftKey: true })
+}
+
+export const input = <value>
+    <document>
+        <preformat>
+            Some<anchor/> <focus/>preformat
+        </preformat>
+    </document>
+</value>
+
+
+export const output = <value>
+    <document>
+        <preformat>
+            Some
+            {'\n'}
+            {'\n'}
+            <cursor/>preformat
+        </preformat>
+    </document>
+</value>

--- a/test/plugins/preformat/insert-block.js
+++ b/test/plugins/preformat/insert-block.js
@@ -1,0 +1,26 @@
+/** @jsx h */
+
+export default editor => editor.insertBlock({
+    type: 'paragraph',
+    nodes: [{ object: 'text', text: 'Para' }],
+})
+
+export const input = <value>
+    <document>
+        <p>Some <preformat>preformat</preformat> text</p>
+        <preformat>
+            Some preformat
+            <cursor/>
+        </preformat>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <p>Some  text</p>
+        <preformat>
+            Some preformat
+        </preformat>
+        <p>Para<cursor/></p>
+    </document>
+</value>

--- a/test/plugins/preformat/insert-nested.js
+++ b/test/plugins/preformat/insert-nested.js
@@ -1,0 +1,22 @@
+/** @jsx h */
+
+export default editor => editor.insertBlock('preformat')
+
+export const input = <value>
+    <document>
+        <preformat>
+            <cursor/>Preformat
+        </preformat>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <preformat>
+            <cursor/>
+        </preformat>
+        <preformat>
+            Preformat
+        </preformat>
+    </document>
+</value>

--- a/test/plugins/preformat/insert.js
+++ b/test/plugins/preformat/insert.js
@@ -1,0 +1,17 @@
+/** @jsx h */
+
+export default editor => editor.insertBlock('preformat')
+
+export const input = <value>
+    <document>
+        <p>Some<cursor/> preformat</p>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <p>Some</p>
+        <preformat><cursor/></preformat>
+        <p> preformat</p>
+    </document>
+</value>

--- a/test/plugins/preformat/query-active.js
+++ b/test/plugins/preformat/query-active.js
@@ -1,0 +1,22 @@
+/** @jsx h */
+
+export default editor => {
+    let block = editor.value.startBlock
+
+    should.exist(block)
+    block.type.should.not.equal('preformat')
+
+    editor.moveToStartOfNode(editor.value.document.getNode('preformat'))
+    block = editor.value.startBlock
+    should.exist(block)
+    block.type.should.equal('preformat')
+}
+
+export const input = <value>
+    <document>
+        <p>Not<cursor/> a note</p>
+        <preformat key="preformat">
+            Preformat
+        </preformat>
+    </document>
+</value>

--- a/test/plugins/preformat/wrap-with-preformat.js
+++ b/test/plugins/preformat/wrap-with-preformat.js
@@ -1,0 +1,27 @@
+/** @jsx h */
+
+export default editor => {
+    const { value: { selection: { anchor } } } = editor
+
+    editor.moveToFocus()
+        .splitBlock()
+        .moveTo(anchor.path, anchor.offset)
+        .splitBlock()
+        .setNodeByKey(editor.value.startBlock.key, 'preformat')
+}
+
+export const input = <value>
+    <document>
+        <p>Some <anchor/>text is<focus/> here</p>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <p>Some </p>
+        <preformat>
+            <cursor/>text is
+        </preformat>
+        <p> here</p>
+    </document>
+</value>

--- a/test/util/compareHtml.js
+++ b/test/util/compareHtml.js
@@ -119,6 +119,7 @@ const BLOCK_NODES = [
     'figure',
     'list',
     'media',
+    'preformat',
     'problem',
     'section',
     'seealso',

--- a/test/util/h.js
+++ b/test/util/h.js
@@ -29,6 +29,7 @@ export default global.h = createHyperscript({
         },
         ol: 'ol_list',
         p: 'paragraph',
+        preformat: 'preformat',
         quote: 'quotation',
         section: 'section',
         tip: {


### PR DESCRIPTION
Add support for `<preformat>` element.

We decided to support `<preformat>` only as `block` element since `<pre>` is not allowed in `<p>` anyway.