### PR TITLE
Fix for cursor.delete()

### DIFF
--- a/src/persistence/index.js
+++ b/src/persistence/index.js
@@ -151,8 +151,8 @@ export class PersistDB {
 
             if (index && keys) {
                 for (const key of keys) {
-                    await iterate(store.index(index), key, cursor => {
-                        cursor.delete()
+                    await iterate(store.index(index), key, async cursor => {
+                        await cursor.delete()
                         cursor.continue()
                     })
                 }
@@ -261,8 +261,8 @@ export class DocumentDB {
         const changes = tx.objectStore('changes').index('document')
         const contents = tx.objectStore('contents')
 
-        await iterate(changes, this.id, cursor => {
-            cursor.delete()
+        await iterate(changes, this.id, async cursor => {
+            await cursor.delete()
             cursor.continue()
         })
 
@@ -333,8 +333,8 @@ export class DocumentDB {
         const contents = tx.objectStore('contents')
 
         await Promise.all([
-            iterate(changes, this.id, cursor => {
-                cursor.delete()
+            iterate(changes, this.id, async cursor => {
+                await cursor.delete()
                 cursor.continue()
             }),
             promisify(states.delete(this.id)),


### PR DESCRIPTION
`cursor.delete()` is async

If `cursor => {...}` is not `async` I'm getting this error while for. ex. saving document:
`TypeError: f(...) is undefined` for:
```
function iterate(store, ...args) {
    const f = args.pop()

    return new Promise((resolve, reject) => {
        const req = store.openCursor(...args)
        req.onerror = err => reject(err)
        req.onsuccess = event => {
            const cursor = event.target.result
            if (cursor) {
                f(cursor, cursor.value, reject).catch(reject)
            } else {
                resolve()
            }
        }
    })
}
```
from `src/persistance/index.js`

Should we wrap `cursor.delete()` with `promisify`? The `await` statement is acctually not necessary. Using only `async` is enough to make it work.