### PR TITLE
Allow only specified children in list_item

### DIFF
--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -93,7 +93,13 @@ export function TextContent(options=DEFAULT_TEXT_OPTIONS) {
  */
 export function Document(options={}) {
     const {
-        list = {},
+        list = {
+            content: [
+                'ul_list',
+                'ol_list',
+                'paragraph',
+            ],
+        },
     } = options
 
     const content = [
@@ -168,7 +174,13 @@ export function Document(options={}) {
  */
 export function Glossary(options={}) {
     const {
-        list = {},
+        list = {
+            content: [
+                'ul_list',
+                'ol_list',
+                'paragraph',
+            ],
+        },
     } = options
 
     const content = [

--- a/src/plugins/list/index.js
+++ b/src/plugins/list/index.js
@@ -1,4 +1,4 @@
-// Copyright 2018 OpenStax Poland
+// Copyright 2019 OpenStax Poland
 // Licensed under the MIT license. See LICENSE file in the project root for
 // full license text.
 
@@ -6,9 +6,17 @@ import EditList from 'slate-edit-list'
 
 import * as commands from './commands'
 import renderBlock from './render'
+import make_schema from './schema'
 
+/**
+ * @param {EditList~OptionsFormat} options - Object with options for EditList
+ *                                           plugin.
+ * @param {string[]} options.content - List of node types which
+ *                                     are allowed inside list items.
+ */
 export default function List(options) {
     const list = EditList(options)
-    const plugin = { commands, renderBlock }
+    const schema = make_schema(options)
+    const plugin = { commands, renderBlock, schema }
     return [plugin, list]
 }

--- a/src/plugins/list/schema.js
+++ b/src/plugins/list/schema.js
@@ -1,0 +1,59 @@
+// Copyright 2019 OpenStax Poland
+// Licensed under the MIT license. See LICENSE file in the project root for
+// full license text.
+
+function normalizeList(change, error) {
+    const { child, code } = error
+
+    switch (code) {
+    case 'child_type_invalid': {
+        change.unwrapNodeByKey(child.key)
+        break
+    }
+
+    /* istanbul ignore next */
+    default:
+        console.warn('Unhandled list violation:', code)
+        break
+    }
+}
+
+function normalizeListItem(change, error) {
+    const { child, code } = error
+
+    switch (code) {
+    case 'child_type_invalid': {
+        if (child.object === 'text') {
+            change.wrapBlockByKey(child.key, 'paragraph')
+            break
+        }
+        change.unwrapNodeByKey(child.key)
+        break
+    }
+
+    /* istanbul ignore next */
+    default:
+        console.warn('Unhandled list_item violation:', code)
+        break
+    }
+}
+
+export default function make_schema({ content = [] }) {
+    return {
+        rules: [
+            {
+                match: [{ type: 'ul_list' }, { type: 'ol_list' }],
+                nodes: [{ match: [{ type: 'list_item' }] }],
+                normalize: normalizeList,
+            },
+            {
+                match: {
+                    object: 'block',
+                    type: 'list_item',
+                },
+                nodes: [{ match: content.map(type => ({ type })) }],
+                normalize: normalizeListItem,
+            },
+        ],
+    }
+}

--- a/test/plugins/list/insert-invalid-children.js
+++ b/test/plugins/list/insert-invalid-children.js
@@ -1,0 +1,23 @@
+/** @jsx h */
+
+export default editor => editor.insertBlock('definition')
+
+export const input = <value>
+    <document>
+        <ol>
+            <li>
+                <p><cursor/>List</p>
+            </li>
+        </ol>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <ol>
+            <li>
+                <p><cursor/>List</p>
+            </li>
+        </ol>
+    </document>
+</value>

--- a/test/plugins/list/schema-invalid-content.js
+++ b/test/plugins/list/schema-invalid-content.js
@@ -1,0 +1,37 @@
+/** @jsx h */
+
+export default editor => editor.normalize()
+
+export const input = <value>
+    <document>
+        <ol>
+            <li>
+                <p>List</p>
+                <note><p>Note</p></note>
+            </li>
+        </ol>
+        <ul>
+            <li>
+                <p>List</p>
+                <note><p>Note</p></note>
+            </li>
+        </ul>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <ol>
+            <li>
+                <p>List</p>
+            </li>
+        </ol>
+        <note><p>Note</p></note>
+        <ul>
+            <li>
+                <p>List</p>
+            </li>
+        </ul>
+        <note><p>Note</p></note>
+    </document>
+</value>

--- a/test/plugins/list/schema-valid-nested.js
+++ b/test/plugins/list/schema-valid-nested.js
@@ -1,0 +1,31 @@
+/** @jsx h */
+
+export default editor => editor.normalize()
+
+export const input = <value>
+    <document>
+        <ol>
+            <li>
+                <ul>
+                    <li>
+                        <p>List</p>
+                    </li>
+                </ul>
+            </li>
+        </ol>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <ol>
+            <li>
+                <ul>
+                    <li>
+                        <p>List</p>
+                    </li>
+                </ul>
+            </li>
+        </ol>
+    </document>
+</value>


### PR DESCRIPTION
Currently all `block` nodes are allowed in `list_item`
This pr is changing this so now only specified types will be allowed.
It's done by passing `typesChildren` to `List` plugin options (name of prop is consistent with other plugin's option).

Tests are working correctly, but when I drag for example `definition` node into list item, it's not normalized. I can also refresh page and this incorrect item still will be there.
![obraz](https://user-images.githubusercontent.com/31478212/66933617-a09da980-f039-11e9-9772-aa8bf4c0b968.png)
