### PR TITLE
Extend media options

### DIFF
--- a/src/plugins/media/index.js
+++ b/src/plugins/media/index.js
@@ -10,14 +10,19 @@ import * as queries from './queries'
  * @param {string[]} options.inlines - List of inline types which may appear
  *                                     inside an alt text.
  * @param {Function} options.mediaUrl - Return URL for given media file.
+ * @param {Function} options.nodes - List of nodes to match for schema validation.
  */
 export default function Media(options) {
     const {
         inlines = [],
         mediaUrl = name => name,
+        nodes = [
+            { match: { type: 'image' }, min: 1 },
+            { match: { type: 'media_alt' }, min: 1, max: 1 },
+        ],
     } = options
 
-    const schema = make_schema({ inlines })
+    const schema = make_schema({ inlines, nodes })
 
     return {
         renderBlock: renderBlock(mediaUrl),

--- a/src/plugins/media/index.js
+++ b/src/plugins/media/index.js
@@ -10,7 +10,8 @@ import * as queries from './queries'
  * @param {string[]} options.inlines - List of inline types which may appear
  *                                     inside an alt text.
  * @param {Function} options.mediaUrl - Return URL for given media file.
- * @param {Function} options.nodes - List of nodes to match for schema validation.
+ * @param {Function} options.nodes - List of nodes to match
+ *                                   for schema validation.
  */
 export default function Media(options) {
     const {

--- a/src/plugins/media/schema.js
+++ b/src/plugins/media/schema.js
@@ -39,15 +39,12 @@ function normalizeMedia(change, error) {
     }
 }
 
-export default function schema({ inlines }) {
+export default function schema({ inlines, nodes }) {
     return {
         blocks: {
             // TODO: do we actually want to keep multiple versions?
             media: {
-                nodes: [
-                    { match: { type: 'image' }, min: 1 },
-                    { match: { type: 'media_alt' }, min: 1, max: 1 },
-                ],
+                nodes: nodes,
                 normalize: normalizeMedia,
             },
             media_alt: {

--- a/src/plugins/media/schema.js
+++ b/src/plugins/media/schema.js
@@ -44,7 +44,7 @@ export default function schema({ inlines, nodes }) {
         blocks: {
             // TODO: do we actually want to keep multiple versions?
             media: {
-                nodes: nodes,
+                nodes,
                 normalize: normalizeMedia,
             },
             media_alt: {

--- a/src/plugins/media/schema.js
+++ b/src/plugins/media/schema.js
@@ -9,8 +9,8 @@ function normalizeMedia(change, error) {
 
     switch (violation) {
     case 'child_min_invalid':
-        if (error.index === 1) {
-            change.insertNodeByKey(node.key, 1, Block.create({
+        if (!node.nodes.find(n => n.type === 'media_alt')) {
+            change.insertNodeByKey(node.key, node.nodes.size, Block.create({
                 type: 'media_alt',
                 nodes: [Text.create(node.data.get('alt'))],
             }))
@@ -23,7 +23,7 @@ function normalizeMedia(change, error) {
         if (key === 'alt') {
             const mediaAlt = node.nodes.find(n => n.type === 'media_alt')
             if (!mediaAlt) {
-                change.insertNodeByKey(node.key, 1, Block.create({
+                change.insertNodeByKey(node.key, node.nodes.size, Block.create({
                     type: 'media_alt',
                     nodes: [Text.create(node.data.get('alt'))],
                 }))


### PR DESCRIPTION
Allow declaring `nodes` for slate's schema validation for `Media` plugin