### PR TITLE
Add support for foreign tag

### DIFF
--- a/src/cnxml/text.js
+++ b/src/cnxml/text.js
@@ -11,6 +11,7 @@
 import React from 'react'
 
 import { inline } from './util'
+import { NAMESPACES } from './xml'
 
 export const DOCUMENT_REFERENCE = inline(null, null, 'docref', 'link')
 
@@ -184,10 +185,40 @@ function se_footnote(obj, children) {
 
 export const FOOTNOTE = inline('footnote', de_footnote, 'footnote', se_footnote)
 
+/**
+ * Process data for foreign.
+ */
+function de_foreign(el) {
+    return {
+        object: 'inline',
+        type: 'foreign',
+        data: {
+            lang: el.getAttributeNS(NAMESPACES.xml, 'lang'),
+        },
+    }
+}
+
+/**
+ * Serializer for foreign.
+ */
+function se_foreign(obj, children) {
+    const attrs = {}
+    const lang = obj.data.get('lang')
+
+    if (lang) {
+        attrs.xmlLang = lang
+    }
+
+    return <foreign {...attrs}>{children}</foreign>
+}
+
+export const FOREIGN = inline('foreign', de_foreign, 'foreign', se_foreign)
+
 export const TEXT_CONTENT = [
     DOCUMENT_REFERENCE,
     EMPHASIS,
     FOOTNOTE,
+    FOREIGN,
     LINK,
     STRONG,
     SUBSCRIPT,

--- a/src/plugins/foreign/index.js
+++ b/src/plugins/foreign/index.js
@@ -1,0 +1,20 @@
+// Copyright 2019 OpenStax Poland
+// Licensed under the MIT license. See LICENSE file in the project root for
+// full license text.
+
+import renderInline from './render'
+import make_schema from './schema'
+
+/**
+ * @param {string[]} options.marks - List of mark types which may appear inside
+ *                                   a foreign.
+ */
+export default function Foreign(options={}) {
+    const {
+        marks = [],
+    } = options
+
+    const schema = make_schema({ marks })
+
+    return { renderInline, schema }
+}

--- a/src/plugins/foreign/render.js
+++ b/src/plugins/foreign/render.js
@@ -1,0 +1,16 @@
+// Copyright 2019 OpenStax Poland
+// Licensed under the MIT license. See LICENSE file in the project root for
+// full license text.
+
+import React from 'react'
+
+/* eslint-disable react/prop-types */
+export default function renderInline(
+    { node, children, attributes },
+    editor,
+    next,
+) {
+    if (node.type !== 'foreign') return next()
+
+    return <span className="foreign" {...attributes}>{children}</span>
+}

--- a/src/plugins/foreign/schema.js
+++ b/src/plugins/foreign/schema.js
@@ -1,0 +1,32 @@
+// Copyright 2019 OpenStax Poland
+// Licensed under the MIT license. See LICENSE file in the project root for
+// full license text.
+
+function normalizeForeign(editor, error) {
+    const { code, node } = error
+
+    switch (code) {
+    case 'node_text_invalid':
+        editor.removeNodeByKey(node.key)
+        break
+
+    default:
+        console.warn('Unhandled foreign violation', code)
+        break
+    }
+}
+
+export default function schema({ marks }) {
+    return {
+        inlines: {
+            foreign: {
+                marks: marks.map(type => ({ type })),
+                data: {
+                    lang: l => l == null || typeof l === 'string',
+                },
+                text: s => s.length,
+                normalize: normalizeForeign,
+            },
+        },
+    }
+}

--- a/src/plugins/index.js
+++ b/src/plugins/index.js
@@ -8,6 +8,7 @@ import Definition from './definition'
 import Exercise from './exercise'
 import Figure from './figure'
 import Footnote from './footnote'
+import Foreign from './foreign'
 import GlossaryDocument from './glossary'
 import List from './list'
 import Media from './media'
@@ -68,6 +69,7 @@ export function TextContent(options=DEFAULT_TEXT_OPTIONS) {
     return [
         Code(options.code),
         Footnote({ marks }),
+        Foreign({ marks }),
         Preformat({ marks, ...options.preformat }),
         Term({ marks, ...options.term }),
         Text({ marks }),

--- a/test/cnxml/de/inline.js
+++ b/test/cnxml/de/inline.js
@@ -15,6 +15,7 @@ links to other elements (<link target-id="f1" />),
 elements in other documents (<link target-id="f1" document="d1" />),
 other <link document="d1">documents</link>,
 <footnote id="footnote-id">footnotes</footnote>,
+<foreign xml:lang="pl">słowa obce</foreign>,
 and <link url="https://example.test">external links</link>.</para>
 `.replace(/\s+/g, ' ')
 
@@ -43,6 +44,8 @@ export const outputContent = <value>
             <docref document="d1">documents</docref>
             {", "}
             <footnote key="footnote-id">footnotes</footnote>
+            {", "}
+            <foreign lang="pl">słowa obce</foreign>
             {", and "}
             <link url="https://example.test">external links</link>
             .

--- a/test/cnxml/se/inline.js
+++ b/test/cnxml/se/inline.js
@@ -23,6 +23,8 @@ export const inputContent = <value>
             <xref target="f1"><text/></xref>
             {"), "}
             <footnote key="footnote-id">footnotes</footnote>
+            {", "}
+            <foreign lang="pl">słowa obce</foreign>
             {", and "}
             <link url="https://example.test">external links</link>
             .
@@ -41,5 +43,6 @@ export const output = cnxml`
 <sub>subscript</sub>,
 links to other elements (<link target-id="f1" />),
 <footnote id="footnote-id">footnotes</footnote>,
+<foreign xml:lang="pl">słowa obce</foreign>,
 and <link url="https://example.test">external links</link>.</para>
 `.replace(/\s+/g, ' ')

--- a/test/plugins/foreign/change-lang.js
+++ b/test/plugins/foreign/change-lang.js
@@ -1,0 +1,22 @@
+/** @jsx h */
+
+export default editor => {
+    const foreign = editor.value.startInline
+    editor.setNodeByKey(foreign.key, {
+        data: {
+            lang: 'pl',
+        },
+    })
+}
+
+export const input = <value>
+    <document>
+        <p>Before <foreign><cursor/>foreign</foreign> after</p>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <p>Before <foreign lang="pl"><cursor/>foreign</foreign> after</p>
+    </document>
+</value>

--- a/test/plugins/foreign/handle-backspace.js
+++ b/test/plugins/foreign/handle-backspace.js
@@ -1,0 +1,20 @@
+/** @jsx h */
+
+export default editor => {
+    editor.run('onKeyDown', { key: 'Backspace' })
+    editor.run('onKeyDown', { key: 'Backspace' })
+}
+
+export const input = <value>
+    <document>
+        <p>Before <foreign>Te<cursor/></foreign></p>
+        <p>After</p>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <p>Before <cursor/></p>
+        <p>After</p>
+    </document>
+</value>

--- a/test/plugins/foreign/handle-delete.js
+++ b/test/plugins/foreign/handle-delete.js
@@ -1,0 +1,29 @@
+/** @jsx h */
+
+export default editor => editor.run('onKeyDown', { key: 'Delete' })
+
+export const input = <value>
+    <document>
+        <p>
+            Before<cursor/>
+            <foreign>
+                Text
+            </foreign>
+            <text/>
+        </p>
+        <p>After</p>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <p>
+            Before<cursor/>
+            <foreign>
+                ext
+            </foreign>
+            <text/>
+        </p>
+        <p>After</p>
+    </document>
+</value>

--- a/test/plugins/foreign/handle-enter-inside-foreign.js
+++ b/test/plugins/foreign/handle-enter-inside-foreign.js
@@ -1,0 +1,16 @@
+/** @jsx h */
+
+export default editor => editor.run('onKeyDown', { key: 'Enter' })
+
+export const input = <value>
+    <document>
+        <p>Before <foreign>te<cursor/>xt</foreign> after</p>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <p>Before <foreign>te</foreign><text/></p>
+        <p><text/><foreign><cursor/>xt</foreign> after</p>
+    </document>
+</value>

--- a/test/plugins/foreign/insert-nested-inline.js
+++ b/test/plugins/foreign/insert-nested-inline.js
@@ -1,0 +1,27 @@
+/** @jsx h */
+
+export default editor => editor.wrapInline({ type: 'term' })
+
+// There is probably a bug in slate which causes selection to
+// be moved at the end for term.
+export const checkSelection = false
+
+export const input = <value>
+    <document>
+        <p>
+            <text/>
+            <foreign>Foreign <anchor/>term<focus/> text</foreign>
+            <text/>
+        </p>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <p>
+            <text/>
+            <foreign>Foreign <term><anchor/>term</term><focus/> text</foreign>
+            <text/>
+        </p>
+    </document>
+</value>

--- a/test/plugins/foreign/schema-bare-foreign.js
+++ b/test/plugins/foreign/schema-bare-foreign.js
@@ -1,0 +1,15 @@
+/** @jsx h */
+
+export default editor => editor.normalize()
+
+export const input = <value>
+    <document>
+        <foreign>Foreign</foreign>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <p><text/></p>
+    </document>
+</value>

--- a/test/plugins/foreign/wrap-as-foreign.js
+++ b/test/plugins/foreign/wrap-as-foreign.js
@@ -1,0 +1,15 @@
+/** @jsx h */
+
+export default editor => editor.wrapInline({ type: 'foreign' })
+
+export const input = <value>
+    <document>
+        <p>Before <anchor/>foreign<focus/> after</p>
+    </document>
+</value>
+
+export const output = <value>
+    <document>
+        <p>Before <foreign><anchor/>foreign</foreign><focus/> after</p>
+    </document>
+</value>

--- a/test/plugins/index.js
+++ b/test/plugins/index.js
@@ -36,6 +36,7 @@ describe('Plugins', () => {
     fixtures(__dirname, 'exercise', testPlugin(CONTENT_PLUGINS))
     fixtures(__dirname, 'figure', testPlugin(CONTENT_PLUGINS))
     fixtures(__dirname, 'footnote', testPlugin(CONTENT_PLUGINS))
+    fixtures(__dirname, 'foreign', testPlugin(CONTENT_PLUGINS))
     fixtures(__dirname, 'list', testPlugin(CONTENT_PLUGINS))
     fixtures(__dirname, 'preformat', testPlugin(CONTENT_PLUGINS))
     fixtures(__dirname, 'quotation', testPlugin(CONTENT_PLUGINS))

--- a/test/util/h.js
+++ b/test/util/h.js
@@ -47,6 +47,7 @@ export default global.h = createHyperscript({
         codeinline: 'code',
         docref: 'docref',
         footnote: 'footnote',
+        foreign: 'foreign',
         link: 'link',
         xref: 'xref',
         term: 'term',


### PR DESCRIPTION
Add support for foreign tag.

Additionally add `xml:lang` attribute - I've assumed that since we support importing cnxml we do not want to make this attribute required.

Things to consider:
Should we validate `data.lang` against languages codes from: https://github.com/openstax-poland/adaptarr-front/blob/master/src/locale/data.json ?
On the front end side user will be able to choose only from those codes.