### PR TITLE
Add custom alt-text element

### DIFF
--- a/src/cnxml/xml.js
+++ b/src/cnxml/xml.js
@@ -10,9 +10,10 @@ import React from 'react'
  * CNXML expects.
  */
 
-const NAMESPACES = {
+export const NAMESPACES = {
     xml: 'http://www.w3.org/XML/1998/namespace',
     cmlnle: 'http://katalysteducation.org/cmlnle/1.0',
+    editing: 'http://adaptarr.naukosfera.com/editing/1.0',
 }
 
 const SPECIAL_PROPS = [

--- a/src/plugins/preformat/render.js
+++ b/src/plugins/preformat/render.js
@@ -7,7 +7,7 @@ import React from 'react'
 export default function renderBlock(
     { node, children, attributes },
     editor,
-    next
+    next,
 ) {
     if (node.type === 'preformat') {
         return <pre className="preformat" {...attributes}>{children}</pre>


### PR DESCRIPTION
Media alt is now serialized to custom <kbd>alt-text</kbd> element with our editing namespace