### PR TITLE
Add support for mime-type for images

### DIFF
--- a/src/cnxml/document.js
+++ b/src/cnxml/document.js
@@ -129,17 +129,30 @@ export const FIGURE = block(
 /**
  * Process data for images.
  */
-function image(el) {
+function de_image(el) {
     return {
         type: 'image',
         isVoid: true,
         data: {
             src: el.getAttribute('src'),
+            mime: el.getAttribute('mime-type'),
         },
     }
 }
 
-export const IMAGE = block('image', image, 'image', 'image')
+/**
+ * Serializer for images.
+ */
+function se_image(obj) {
+    const attrs = {
+        src: obj.data.get('src'),
+        'mime-type': obj.data.get('mime'),
+    }
+
+    return <image {...attrs} />
+}
+
+export const IMAGE = block('image', de_image, 'image', se_image)
 
 /**
  * Process data for list nodes.

--- a/src/plugins/figure/commands.js
+++ b/src/plugins/figure/commands.js
@@ -22,7 +22,7 @@ import { Block, Range, Text } from 'slate'
 export function insertFigure(change, media) {
     const image = Block.create({
         type: media.mime.split('/', 1)[0],
-        data: { src: media.name },
+        data: { src: media.name, mime: media.mime },
     })
     const media_node = Block.create({
         type: 'media',
@@ -66,7 +66,7 @@ export function insertSubfigure(change, media) {
 
     const image = Block.create({
         type: media.mime.split('/', 1)[0],
-        data: { src: media.name },
+        data: { src: media.name, mime: media.mime },
     })
 
     const media_node = Block.create({

--- a/src/plugins/media/schema.js
+++ b/src/plugins/media/schema.js
@@ -64,6 +64,11 @@ export default function schema({ inlines }) {
                 isVoid: true,
                 data: {
                     src: Boolean,
+                    // mime should be required, but since it wasn't earlier
+                    // some drafts doesn't have it.
+                    // Remove check for null after few weeks when all images
+                    // will have mime set by front end (adaptarr-front).
+                    mime: m => m == null || typeof m === 'string',
                 },
             },
         },

--- a/test/cnxml/de/block-in-para.js
+++ b/test/cnxml/de/block-in-para.js
@@ -7,7 +7,7 @@ export const input = cnxml`
         <item>List item</item>
     </list>More text<figure id="f1">
         <media alt="This should not be inline">
-            <image src="f1.png" />
+            <image src="f1.png" mime-type="image/png" />
         </media>
     </figure>Even more text</para>
 `
@@ -23,7 +23,7 @@ export const outputContent = <value>
         <p>More text</p>
         <figure key="f1" class={List()}>
             <media alt="This should not be inline">
-                <img src="f1.png"><text/></img>
+                <img src="f1.png" mime="image/png"><text/></img>
                 <mediaalt>This should not be inline</mediaalt>
             </media>
         </figure>

--- a/test/cnxml/de/figure-subfigures.js
+++ b/test/cnxml/de/figure-subfigures.js
@@ -6,13 +6,13 @@ export const input = cnxml`
 <figure id="f1">
     <subfigure id="f1-1">
         <media alt="First subfigure's content">
-            <image src="f1.png" />
+            <image src="f1.png" mime-type="image/png" />
         </media>
         <caption>First subfigure</caption>
     </subfigure>
     <subfigure id="f1-2">
         <media alt="Second subfigure's content">
-            <image src="f2.png" />
+            <image src="f2.png" mime-type="image/png" />
         </media>
     </subfigure>
     <caption>Two subfigures</caption>
@@ -24,14 +24,14 @@ export const outputContent = <value>
         <figure key="f1" class={List()}>
             <figure key="f1-1" class={List()}>
                 <media alt="First subfigure's content">
-                    <img src="f1.png"><text/></img>
+                    <img src="f1.png" mime="image/png"><text/></img>
                     <mediaalt>First subfigure&apos;s content</mediaalt>
                 </media>
                 <figcaption>First subfigure</figcaption>
             </figure>
             <figure key="f1-2" class={List()}>
                 <media alt="Second subfigure's content">
-                    <img src="f2.png"><text/></img>
+                    <img src="f2.png" mime="image/png"><text/></img>
                     <mediaalt>Second subfigure&apos;s content</mediaalt>
                 </media>
             </figure>

--- a/test/cnxml/de/figure.js
+++ b/test/cnxml/de/figure.js
@@ -5,7 +5,7 @@ import { List } from 'immutable'
 export const input = cnxml`
 <figure id="f1">
     <media alt="Figure content">
-        <image src="f1.png" />
+        <image src="f1.png" mime-type="image/png" />
     </media>
     <caption>Figure caption</caption>
 </figure>
@@ -15,7 +15,7 @@ export const outputContent = <value>
     <document>
         <figure key="f1" class={List()}>
             <media alt="Figure content">
-                <img src="f1.png"><text/></img>
+                <img src="f1.png" mime="image/png"><text/></img>
                 <mediaalt>Figure content</mediaalt>
             </media>
             <figcaption>Figure caption</figcaption>

--- a/test/cnxml/de/whitespace.js
+++ b/test/cnxml/de/whitespace.js
@@ -22,7 +22,7 @@ export const input = cnxml`
 
 <figure>
     <media alt="Alt">
-        <image src="example.png" />
+        <image src="example.png" mime-type="image/png"/>
     </media>
     <caption>
         excessive      white  space
@@ -46,7 +46,7 @@ export const outputContent = <value>
         </note>
         <figure class={List()}>
             <media alt="Alt">
-                <img src="example.png"><text/></img>
+                <img src="example.png" mime="image/png"><text/></img>
                 <mediaalt>Alt</mediaalt>
             </media>
             <figcaption>excessive white space</figcaption>

--- a/test/cnxml/se/figure-subfigures.js
+++ b/test/cnxml/se/figure-subfigures.js
@@ -5,14 +5,14 @@ export const inputContent = <value>
         <figure key="f1">
             <figure key="f1-1">
                 <media>
-                    <img src="f1.png"><text/></img>
+                    <img src="f1.png" mime="image/png"><text/></img>
                     <mediaalt>First subfigure&apos;s content</mediaalt>
                 </media>
                 <figcaption>First subfigure</figcaption>
             </figure>
             <figure key="f1-2">
                 <media>
-                    <img src="f2.png"><text/></img>
+                    <img src="f2.png" mime="image/png"><text/></img>
                     <mediaalt>Second subfigure&apos;s content</mediaalt>
                 </media>
             </figure>
@@ -25,13 +25,13 @@ export const output = cnxml`
 <figure id="f1">
     <subfigure id="f1-1">
         <media alt="First subfigure's content">
-            <image src="f1.png" />
+            <image src="f1.png" mime-type="image/png" />
         </media>
         <caption>First subfigure</caption>
     </subfigure>
     <subfigure id="f1-2">
         <media alt="Second subfigure's content">
-            <image src="f2.png" />
+            <image src="f2.png" mime-type="image/png" />
         </media>
     </subfigure>
     <caption>Two subfigures</caption>

--- a/test/cnxml/se/figure.js
+++ b/test/cnxml/se/figure.js
@@ -4,7 +4,7 @@ export const inputContent = <value>
     <document>
         <figure key="f1">
             <media>
-                <img src="f1.png"><text/></img>
+                <img src="f1.png" mime="image/png"><text/></img>
                 <mediaalt>Figure content</mediaalt>
             </media>
             <figcaption>Figure caption</figcaption>
@@ -15,7 +15,7 @@ export const inputContent = <value>
 export const output = cnxml`
 <figure id="f1">
     <media alt="Figure content">
-        <image src="f1.png" />
+        <image src="f1.png" mime-type="image/png" />
     </media>
     <caption>Figure caption</caption>
 </figure>

--- a/test/plugins/figure/handle-enter-in-caption.js
+++ b/test/plugins/figure/handle-enter-in-caption.js
@@ -6,7 +6,7 @@ export const input = <value>
     <document>
         <figure>
             <media alt="First picture">
-                <img src="first.png"><text/></img>
+                <img src="first.png" mime="image/png"><text/></img>
                 <mediaalt>First picture</mediaalt>
             </media>
             <figcaption>Cap<cursor/>tion</figcaption>
@@ -18,7 +18,7 @@ export const output = <value>
     <document>
         <figure>
             <media alt="First picture">
-                <img src="first.png"><text/></img>
+                <img src="first.png" mime="image/png"><text/></img>
                 <mediaalt>First picture</mediaalt>
             </media>
             <figcaption>Cap</figcaption>

--- a/test/plugins/figure/insert-caption.js
+++ b/test/plugins/figure/insert-caption.js
@@ -6,7 +6,9 @@ export const input = <value>
     <document>
         <figure>
             <media alt="First picture">
-                <img src="first.png"><text><cursor/></text></img>
+                <img src="first.png" mime="image/png">
+                    <text><cursor/></text>
+                </img>
                 <mediaalt>First picture</mediaalt>
             </media>
         </figure>
@@ -17,7 +19,7 @@ export const output = <value>
     <document>
         <figure>
             <media alt="First picture">
-                <img src="first.png"><text/></img>
+                <img src="first.png" mime="image/png"><text/></img>
                 <mediaalt>First picture</mediaalt>
             </media>
             <figcaption><text><cursor/></text></figcaption>

--- a/test/plugins/figure/insert-subfigure.js
+++ b/test/plugins/figure/insert-subfigure.js
@@ -10,7 +10,7 @@ export const input = <value>
     <document>
         <figure>
             <media alt="First picture">
-                <img src="first.png"><text/></img>
+                <img src="first.png" mime="image/png"><text/></img>
                 <mediaalt>First picture</mediaalt>
             </media>
             <figcaption><cursor/>Caption</figcaption>
@@ -23,14 +23,14 @@ export const output = <value>
         <figure>
             <figure>
                 <media alt="First picture">
-                    <img src="first.png"><text/></img>
+                    <img src="first.png" mime="image/png"><text/></img>
                     <mediaalt>First picture</mediaalt>
                 </media>
                 <figcaption><cursor/>Caption</figcaption>
             </figure>
             <figure>
                 <media alt="Second picture">
-                    <img src="second.png"><text/></img>
+                    <img src="second.png" mime="image/png"><text/></img>
                     <mediaalt>Second picture</mediaalt>
                 </media>
             </figure>

--- a/test/plugins/figure/insert-third-subfigure.js
+++ b/test/plugins/figure/insert-third-subfigure.js
@@ -11,14 +11,14 @@ export const input = <value>
         <figure>
             <figure>
                 <media alt="First picture">
-                    <img src="first.png"><text/></img>
+                    <img src="first.png" mime="image/png"><text/></img>
                     <mediaalt>First picture</mediaalt>
                 </media>
                 <figcaption><cursor/>Caption</figcaption>
             </figure>
             <figure>
                 <media alt="Second picture">
-                    <img src="second.png"><text/></img>
+                    <img src="second.png" mime="image/png"><text/></img>
                     <mediaalt>Second picture</mediaalt>
                 </media>
             </figure>
@@ -31,20 +31,20 @@ export const output = <value>
         <figure>
             <figure>
                 <media alt="First picture">
-                    <img src="first.png"><text/></img>
+                    <img src="first.png" mime="image/png"><text/></img>
                     <mediaalt>First picture</mediaalt>
                 </media>
                 <figcaption><cursor/>Caption</figcaption>
             </figure>
             <figure>
                 <media alt="Second picture">
-                    <img src="second.png"><text/></img>
+                    <img src="second.png" mime="image/png"><text/></img>
                     <mediaalt>Second picture</mediaalt>
                 </media>
             </figure>
             <figure>
                 <media alt="Third picture">
-                    <img src="third.png"><text/></img>
+                    <img src="third.png" mime="image/png"><text/></img>
                     <mediaalt>Third picture</mediaalt>
                 </media>
             </figure>

--- a/test/plugins/figure/insert.js
+++ b/test/plugins/figure/insert.js
@@ -17,7 +17,9 @@ export const output = <value>
         <p><text/></p>
         <figure>
             <media alt="First picture">
-                <img src="first.png"><text><cursor/></text></img>
+                <img src="first.png" mime="image/png">
+                    <text><cursor/></text>
+                </img>
                 <mediaalt>First picture</mediaalt>
             </media>
         </figure>

--- a/test/plugins/figure/query-active.js
+++ b/test/plugins/figure/query-active.js
@@ -26,7 +26,7 @@ export const input = <value>
         <p><cursor/>Not a figure</p>
         <figure key="figure-1">
             <media>
-                <img src="first.png"><text/></img>
+                <img src="first.png" mime="image/png"><text/></img>
                 <mediaalt><text/></mediaalt>
             </media>
             <figcaption key="first">Simple figure</figcaption>
@@ -34,14 +34,14 @@ export const input = <value>
         <figure key="figure-2">
             <figure key="figure-3">
                 <media>
-                    <img src="second.png"><text/></img>
+                    <img src="second.png" mime="image/png"><text/></img>
                     <mediaalt><text/></mediaalt>
                 </media>
                 <figcaption key="second">Nested figure</figcaption>
             </figure>
             <figure>
                 <media>
-                    <img src="third.png"><text/></img>
+                    <img src="third.png" mime="image/png"><text/></img>
                     <mediaalt><text/></mediaalt>
                 </media>
             </figure>


### PR DESCRIPTION
We need to add support for `mime-type` for `image` elements simultaneously to releasing Hercules which includes cnxml validation.

This pr is adding support for `data.mime` and de/serialization for those attributes.

Currently we need to allow `data.mime` to be set to `undefined` since all drafts with images will fail this validation.

I'll add pr in front end which will set `mime` for every image when document is loaded.

https://github.com/openstax-poland/adaptarr-front/issues/238