### PR TITLE
Add support for XML processing instructions in <content>

### DIFF
--- a/src/cnxml/index.js
+++ b/src/cnxml/index.js
@@ -7,7 +7,7 @@ import React from 'react'
 
 import render from './xml'
 import { TEXT_CONTENT } from './text'
-import { DEFAULT } from './util'
+import { DEFAULT, PROCESSING_INSTRUCTION } from './util'
 import { DOCUMENT } from './document'
 import { GLOSSARY } from './glossary'
 
@@ -65,7 +65,7 @@ export default class CNXML {
             glossaryRules = [],
         } = args
         this.document = new Html({
-            rules: [...documentRules, ...DOCUMENT, ...TEXT_CONTENT, DEFAULT],
+            rules: [PROCESSING_INSTRUCTION, ...documentRules, ...DOCUMENT, ...TEXT_CONTENT, DEFAULT],
             defaultBlock: 'invalid',
             parseHtml,
         })
@@ -124,5 +124,5 @@ function parseHtml(root) {
     // XXX: slate-html-serializer deserializes root element from childNodes
     // without using custom deserializers, which makes it impossible to ignore
     // white space in <content> and <glossary>.
-    return { childNodes: root.children || [] }
+    return { childNodes: Array.from(root.childNodes || []).filter(n => n.nodeType != n.TEXT_NODE) }
 }

--- a/src/cnxml/util.js
+++ b/src/cnxml/util.js
@@ -401,3 +401,29 @@ export const DEFAULT = {
         return mixedContent(el, next)
     },
 }
+
+export const PROCESSING_INSTRUCTION = {
+    deserialize(el, next) {
+        if (el.nodeType != Node.PROCESSING_INSTRUCTION_NODE) {
+            return undefined
+        }
+
+        return {
+            object: 'block',
+            type: 'pi',
+            isVoid: true,
+            data: {
+                target: el.target,
+                value: el.data,
+            },
+        }
+    },
+
+    serialize(obj) {
+        if (obj.type !== 'pi') {
+            return undefined
+        }
+
+        return <pi target={obj.data.get('target')} value={obj.data.get('value')} />
+    },
+}

--- a/src/cnxml/xml.js
+++ b/src/cnxml/xml.js
@@ -84,6 +84,10 @@ class Renderer {
     }
 
     renderElement(element) {
+        if (element.type === 'pi') {
+            return this.doc.createProcessingInstruction(element.props.target, element.props.value)
+        }
+
         const ns = element.props.xmlns || this.ns
         const node = this.doc.createElementNS(ns, element.type)
 

--- a/src/plugins/section/schema.js
+++ b/src/plugins/section/schema.js
@@ -102,6 +102,7 @@ export default function schema(options) {
     return {
         document: {
             nodes: [
+                { match: { type: 'pi' } },
                 {
                     match: content,
                     min: 1,
@@ -120,6 +121,9 @@ export default function schema(options) {
                 ],
                 next: { type: 'section' },
                 normalize: normalizeSection,
+            },
+            pi: {
+                isVoid: true,
             },
         },
     }

--- a/test/cnxml/de/processing-instruction.js
+++ b/test/cnxml/de/processing-instruction.js
@@ -1,0 +1,13 @@
+/** @jsx h */
+
+export const input = cnxml`
+<?cnx.eoc class="summary" title="Summary"?>
+<para>Content</para>
+`
+
+export const outputContent = <value>
+    <document>
+        <pi target="cnx.eoc" value='class="summary" title="Summary"'><text/></pi>
+        <p>Content</p>
+    </document>
+</value>

--- a/test/cnxml/se/processing-instruction.js
+++ b/test/cnxml/se/processing-instruction.js
@@ -1,0 +1,13 @@
+/** @jsx h */
+
+export const inputContent = <value>
+    <document>
+        <pi target="cnx.eoc" value='class="summary" title="Summary"'><text/></pi>
+        <p>Content</p>
+    </document>
+</value>
+
+export const output = cnxml`
+<?cnx.eoc class="summary" title="Summary"?>
+<para>Content</para>
+`

--- a/test/util/h.js
+++ b/test/util/h.js
@@ -30,6 +30,10 @@ export default global.h = createHyperscript({
         },
         ol: 'ol_list',
         p: 'paragraph',
+        pi: {
+            type: 'pi',
+            isVoid: true,
+        },
         preformat: 'preformat',
         proof: 'rule_proof',
         quote: 'quotation',


### PR DESCRIPTION
The old XSLT-based PDF rendering pipeline requires some properties to be set via processing instructions in an introduction to a chapter. For example the introduction to _Introduction to Psychology_ from _Psychology_ contains

```xml
<?cnx.eoc class="summary" title="Summary"?>
<?cnx.eoc class="review-questions" title="Review Questions"?>
<?cnx.eoc class="critical-thinking" title="Critical Thinking Questions"?>
<?cnx.eoc class="personal-application" title="Personal Application Questions"?>
<?cnx.eoc class="references" title="References"?>
```

we need to be able to load and save documents without destroying those instructions.

There is no need for users to be able to edit those instructions. They can be displayed in the UI as non-editable elements (with `contenteditable="false"`).